### PR TITLE
SRE-406: Include querystring in `state` value to OKTA.

### DIFF
--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -420,7 +420,10 @@ function getRedirectPayload({ evt, queryString, decodedToken, headers }) {
 function getOidcRedirectPayload(request) {
 	const { nonce, hash } = getNonceAndHash();
 	config.AUTH_REQUEST.nonce = nonce;
-	config.AUTH_REQUEST.state = request.uri; // Redirect to Authorization Server
+
+	const queryString = QueryString.parse(request.querystring);
+	var state = `${request.uri}?${QueryString.stringify(queryString)}`;
+	config.AUTH_REQUEST.state = state; // Redirect to Authorization Server
 
 	return {
 		status: '302',


### PR DESCRIPTION
This commit updates the `getOidcRedirectPayload()` function to include
the request query string as part of the `state` key passed to OKTA.